### PR TITLE
Fix egg configuration for Minecraft Java server

### DIFF
--- a/eggs/minecraft/java.yaml
+++ b/eggs/minecraft/java.yaml
@@ -4,8 +4,8 @@ id: 10
 nestId: 1  # "Game Servers"
 name: "Minecraft Java – Paper"
 description: "High-performance PaperMC server for Minecraft Java Edition"
-dockerImage: "itzg/minecraft-server:latest"
-startupCmd: ""  # Startup handled by image entrypoint; see https://hub.docker.com/r/itzg/minecraft-server
+image: "itzg/minecraft-server:latest"
+startup: "/start"
 
 # Environment variables expected by the image.
 # Only the default value is set here; see image docs for details.


### PR DESCRIPTION
This pull request updates the configuration for the Minecraft Java egg to include the necessary image and startup command that were previously missing. The changes in `eggs/minecraft/java.yaml` ensure that the egg sync operation can properly utilize the Docker image for the server. With these adjustments, the warning about missing image/startup should be resolved.

---

> This pull request was co-created with Cosine Genie

Original Task: [Velva-cloud-eggs/b1vstt2howx5](https://cosine.sh/spdub9h2id5z/Velva-cloud-eggs/task/b1vstt2howx5)
Author: Ethan Hill
